### PR TITLE
Make able to be viewed directly by fixing error due to comma in string in line 81

### DIFF
--- a/Xbox1NameLookup.csv
+++ b/Xbox1NameLookup.csv
@@ -1,3 +1,4 @@
+Number, Name
 4541000D,007: Agent Under Fire
 45410042,007: Everything or Nothing
 45410026,007: NightFire

--- a/Xbox1NameLookup.csv
+++ b/Xbox1NameLookup.csv
@@ -78,7 +78,7 @@ Number,Name
 53450004,Crazy Taxi 3: High Roller
 4D530021,Crimson Skies: High Road to Revenge
 4B4F0002,Crimson Sea
-55530020,Crouching Tiger "," Hidden Dragon
+55530020,"Crouching Tiger, Hidden Dragon"
 49470013,Dungeons & Dragons: Heroes
 434B0001,Dai Senryaku VII: Modern Military Tactics
 54510004,Dark Summit

--- a/Xbox1NameLookup.csv
+++ b/Xbox1NameLookup.csv
@@ -77,7 +77,7 @@
 53450004,Crazy Taxi 3: High Roller
 4D530021,Crimson Skies: High Road to Revenge
 4B4F0002,Crimson Sea
-55530020,Crouching Tiger, Hidden Dragon
+55530020,Crouching Tiger"," Hidden Dragon
 49470013,Dungeons & Dragons: Heroes
 434B0001,Dai Senryaku VII: Modern Military Tactics
 54510004,Dark Summit

--- a/Xbox1NameLookup.csv
+++ b/Xbox1NameLookup.csv
@@ -1,4 +1,4 @@
-Number, Name
+Number,Name
 4541000D,007: Agent Under Fire
 45410042,007: Everything or Nothing
 45410026,007: NightFire

--- a/Xbox1NameLookup.csv
+++ b/Xbox1NameLookup.csv
@@ -78,7 +78,7 @@ Number,Name
 53450004,Crazy Taxi 3: High Roller
 4D530021,Crimson Skies: High Road to Revenge
 4B4F0002,Crimson Sea
-55530020,Crouching Tiger"," Hidden Dragon
+55530020,Crouching Tiger",Hidden Dragon
 49470013,Dungeons & Dragons: Heroes
 434B0001,Dai Senryaku VII: Modern Military Tactics
 54510004,Dark Summit

--- a/Xbox1NameLookup.csv
+++ b/Xbox1NameLookup.csv
@@ -1,4 +1,4 @@
-Number,Name
+Title ID,Name
 4541000D,007: Agent Under Fire
 45410042,007: Everything or Nothing
 45410026,007: NightFire

--- a/Xbox1NameLookup.csv
+++ b/Xbox1NameLookup.csv
@@ -78,7 +78,7 @@ Number,Name
 53450004,Crazy Taxi 3: High Roller
 4D530021,Crimson Skies: High Road to Revenge
 4B4F0002,Crimson Sea
-55530020,Crouching Tiger",Hidden Dragon
+55530020,Crouching Tiger "," Hidden Dragon
 49470013,Dungeons & Dragons: Heroes
 434B0001,Dai Senryaku VII: Modern Military Tactics
 54510004,Dark Summit


### PR DESCRIPTION
Made it able to be viewed and searched directly on github by fixing error due to comma in string in line 81 by using quotes — check http://tools.ietf.org/html/rfc4180 for reference. 

Might not be helpful for whatever this project is. Just found a direct link to this list of games somewhere on the web. Also added a header. I assumed that the number is the Title ID — if you want to keep this a more accurate description might be necessary...

If this should be not helpful for this project —which I do assume — please feel free to ignore this commit/pull request. 

Greetings, 

goldsteal